### PR TITLE
Checking class exists is insufficient allows for a fatal error when J…

### DIFF
--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -43,7 +43,7 @@ class WC_Regenerate_Images {
 		}
 
 		// Not required when Jetpack Photon is in use.
-		if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) ) {
+		if ( method_exists('Jetpack', 'is_module_active') && Jetpack::is_module_active( 'photon' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
…etpack class is defined without specific method

There are a half dozen stripped-down versions of JetPack's modules like JP Custom CSS, JP Widget visibility, etc... these all define a class called "Jetpack" but don't define all the methods.